### PR TITLE
Semantics and style

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     </h1>
     <textarea id="pubtext" rows="25" cols="100"></textarea>
     <p>
-      <button id="send-message-button">Send Message</button>
+      <button id="send-message-button" type="button">Send Message</button>
     </p>
     <p>
       <a href="info.html">Why did we make this?</a>

--- a/index.html
+++ b/index.html
@@ -1,74 +1,65 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
-    <title>
-      What Have We Done (WHWD)
-    </title>
-    <script src=
-    "https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.0.3/socket.io.js"
-    type="text/javascript">
-    </script>
-    <style type="text/css">
-/*<![CDATA[*/
-    body {
-      background-color #BBB;
-    }
+    <title>What Have We Done (WHWD)</title>
+    <meta charset="utf-8">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.0.3/socket.io.js"></script>
+    <style>
+      body {
+        background-color #BBB;
+        text-align: center;
+      }
 
-    textarea.pubtext {
-      white-space: nowrap;
-      text-overflow: ellipsis;
-    }
-    /*]]>*/
+      textarea.pubtext {
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
+
+      #online-heading {
+        font-face: verdana;
+        color: light-blue;
+      }
     </style>
   </head>
   <body>
-    <center>
-      <h1>
-        <font face="Verdana" color="light-blue">People
-        Online:<span id="online"></span></font>
-      </h1>
-      <textarea id="pubtext" rows="25" cols="100"></textarea>
-      <p>
-        <button type="button" onclick=
-        "socket.emit('announcement', document.getElementById('pubtext').value);">
-        Send Message</button>
-      </p>
-      <p>
-        <a href="info.html">Why did we make this?</a>
-      </p>
-    </center><script type="text/javascript">
-//<![CDATA[
-    var socket = io();
+    <h1 id="online-heading">
+      People Online: <span id="online"></span>
+    </h1>
+    <textarea id="pubtext" rows="25" cols="100"></textarea>
+    <p>
+      <button id="send-message-button">Send Message</button>
+    </p>
+    <p>
+      <a href="info.html">Why did we make this?</a>
+    </p>
+    <script>
+      /*
+      Now, All we do, is work on this file
+      nothing else.
+      Can we do it?
 
-    /*
+      - Lefty
+      */
 
-    Now, All we do, is work on this file
-    nothing else.
-    Can we do it?
+      var socket = io();
 
-    - Lefty
-    */
+      window.addEventListener("load", function() {
+        var online = 0;
+        var pubtext = document.getElementById("pubtext");
 
-    window.addEventListener("load", function() {
-      var online = 0;
+        socket.on("online", function(msg) {
+          online = msg;
+          document.getElementById("online").innerHTML = msg.toString();
+        });
 
-      socket.on("online", function(msg) {
-        online = msg;
-        document.getElementById("online").innerHTML = msg.toString();
-      });
+        socket.on("pubtextchange", function(msg) {
+          pubtext.value = msg.value;
+        });
 
-      socket.on("pubtextchange", function(msg) {
-        document.getElementById("pubtext").value = msg.value
-      });
-
-      pubtext.addEventListener("change", function() {
-        socket.emit("pubtextchange", {
-          value: document.getElementById("pubtext").value
+        document.getElementById("pubtext").addEventListener("change", function() {
+          socket.emit("pubtextchange", {value: pubtext.value});
         });
       });
-    });
-    //]]>
     </script>
   </body>
 </html>


### PR DESCRIPTION
* **Overall, HTML5-ify**
  * Use a simple `<!DOCTYPE html>` rather than the long HTML <5 doctype.
  * Don't use the `xmlns` attribute.
  * Remove [obsolete](https://html.spec.whatwg.org/multipage/obsolete.html#obsolete-but-conforming-features) `type="text/javascript"` attribute.
  * Remove [unnecessary](https://html.spec.whatwg.org/multipage/semantics.html#the-style-element) `type="text/css"` attribute (which automatically defaults to that value).
  * Remove [obsolete](https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features) `<font>` and `<center>` elements in favor of the respective CSS.

* **JS stuff**
  * Clean up changes from #11 (added missing semicolons, improved line spacing).
  * Avoid using `pubtext` "variable" which isn't formally defined anywhere, instead formally create it with the value `document.getElementById("pubtext")` (since `getElementById` is used elsewhere in the code).